### PR TITLE
Scrum 20/create initial configuration of users and profiles in the db

### DIFF
--- a/deploy/seeds/seed_usuarios_iniciais.sql
+++ b/deploy/seeds/seed_usuarios_iniciais.sql
@@ -1,0 +1,38 @@
+-- =====================================================
+-- Script: seed_usuarios_iniciais.sql
+-- Objetivo: Criar usuários iniciais no banco de dados
+-- Autor: Glória Brito
+-- Data: 23/09/2025
+-- Observação: Usuários não terão login funcional, apenas referência interna
+-- =====================================================
+
+-- ==========================
+-- Inserir usuários padrão
+-- ==========================
+-- Campos da tabela usuario:
+-- id     -> SERIAL PRIMARY KEY
+-- nome   -> Nome do usuário
+-- nivel  -> Perfil do usuário (ENUM: Admin, Gestor)
+-- email  -> Email do usuário (único)
+-- senha  -> Senha dummy para preencher o campo
+
+INSERT INTO usuario (nome, nivel, email, senha) VALUES
+  ('Administrador', 'Admin', 'admin@sistema.com', 'senha_dummy'),  -- usuário com login
+  ('Gestor', 'Gestor', 'gestor@sistema.com', 'senha_dummy'),      -- usuário com login
+  ('Cidadão', 'Gestor', 'cidadao@sistema.com', 'senha_dummy');    -- usuário sem login
+
+
+-- ==========================
+-- Conferência (opcional)
+-- ==========================
+-- Visualizar usuários inseridos
+SELECT id, nome, nivel, email FROM usuario;
+
+-- ==========================
+-- Observações finais
+-- ==========================
+-- 1. Este script pode ser rodado em qualquer ambiente de banco de dados
+--    com o modelo definido no arquivo .sql
+-- 2. Como os usuários não terão login, o campo senha pode ser qualquer valor.
+-- 4. Apenas Admin e Gestor poderão autenticar no sistema.
+-- 5. Usuários como Cidadão são apenas referência e não precisam de senha funcional.


### PR DESCRIPTION
[[Infra] Criar configuração inicial de usuários e perfis no banco de dados](https://sqlutionsfatec.atlassian.net/jira/software/projects/SCM/boards/34?selectedIssue=SCM-20)

Este PR adiciona o script inicial de seed para criação de usuários e perfis padrão no banco de dados.

Detalhes

- Criado `nivel_usuario` enum com os perfis: `Admin`, `Gestor` e `Cidadão`.
- Adicionado o script` seed_usuarios_iniciais.sql` para inserir usuários padrão.
- Usuários `Admin` e `Gestor` estão preparados para login.
- Usuário `Cidadão` existe apenas como referência (sem login).
- Script documentado e versionado para garantir consistência entre ambientes.

Por que essa mudança?
Essa configuração garante que os ambientes iniciem com usuários e perfis predefinidos, facilitando a gestão de permissões, os testes de funcionalidades e mantendo o sistema consistente.

Como testar

1. Rodar o script no banco de dados.
2.  Executar a query:

`SELECT id, nome, nivel, email FROM usuario;
`

3. Verificar se os usuários `Admin`, `Gestor` e `Cidadão` foram inseridos corretamente.